### PR TITLE
feat: Add support for podman containers

### DIFF
--- a/defaults/main/post_config.yml
+++ b/defaults/main/post_config.yml
@@ -1,0 +1,10 @@
+---
+# -------------------------
+# Post-config configuration
+# -------------------------
+
+vyos_save_config: true
+
+vyos_run_post_config_script: true
+
+vyos_containers: {}

--- a/tasks/dns/coredns.yml
+++ b/tasks/dns/coredns.yml
@@ -44,19 +44,6 @@
     lstrip_blocks: true
   become: true
 
-- name: dns | coredns | start container
-  containers.podman.podman_container:
-    name: coredns
-    image: "{{ (vyos_coredns['container']['repository'] + ':' + vyos_coredns['container']['tag']) }}"
-    cap_add:
-      - CAP_NET_BIND_SERVICE
-    volume:
-      - "{{ vyos_coredns['config_path'] }}:/config"
-      - "/etc/hosts:/etc/hosts:ro"
-    network: host
-    state: started
-  become: true
-
 - name: dns | coredns | switch to network_cli connection
   set_fact:
     ansible_connection: ansible.netcommon.network_cli

--- a/tasks/post_config/main.yml
+++ b/tasks/post_config/main.yml
@@ -2,7 +2,7 @@
 
 - name: post-config | manage script
   ansible.builtin.import_tasks:
-    file: script.yml
+    file: manage_script.yml
   tags:
     - vyos_post_config_script
 

--- a/tasks/post_config/manage_script.yml
+++ b/tasks/post_config/manage_script.yml
@@ -13,6 +13,13 @@
     lstrip_blocks: true
   become: true
 
+- name: post-config | manage script | run
+  when:
+    vyos_run_post_config_script
+  ansible.builtin.command:
+    cmd: /config/scripts/vyos-postconfig-bootup.script
+  become: true
+
 - name: post-config | manage script | switch to network_cli connection
   set_fact:
     ansible_connection: ansible.netcommon.network_cli

--- a/templates/config/post_config/vyos-postconfig-bootup.script.j2
+++ b/templates/config/post_config/vyos-postconfig-bootup.script.j2
@@ -1,3 +1,5 @@
+#jinja2: lstrip_blocks: "True", trim_blocks: "True"
+{%- from "macros/container.j2" import container with context -%}
 #!/bin/sh
 # This script is executed at boot time after VyOS configuration is fully applied.
 # Any modifications required to work around unfixed bugs
@@ -5,25 +7,26 @@
 
 {% if vyos_coredns['enabled'] %}
 # CoreDNS workaround until podman is fully supported on CLI
-cat <<EOT > /etc/systemd/system/coredns.service
-[Unit]
-Description=CoreDNS container
-Wants=network.target
-After=network-online.target
+{{ container(
+  'coredns',
+  {
+    'image': {
+      'repository': vyos_coredns['container']['repository'],
+      'tag': vyos_coredns['container']['tag']
+    },
+    'volumes': [
+      vyos_coredns['config_path'] + ':/config',
+      '/etc/hosts:/etc/hosts:ro'
+    ],
+    'cap_add': [
+      'CAP_NET_BIND_SERVICE'
+    ],
+    'host-networking': true
+  }
+) }}
+{% endif %}
 
-[Service]
-Restart=on-failure
-TimeoutStopSec=60
-ExecStartPre=/usr/bin/podman rm --force --volumes --ignore coredns
-ExecStart=/usr/bin/podman run -d --rm --net host --cap-add CAP_NET_BIND_SERVICE --name coredns -v {{ vyos_coredns['config_path'] }}:/config -v /etc/hosts:/etc/hosts:ro {{ vyos_coredns['container']['repository'] }}:{{ vyos_coredns['container']['tag'] }}
-ExecStop=/usr/bin/podman stop -t 10 coredns
-ExecStopPost=/usr/bin/podman stop -t 10 coredns
-Type=forking
+{% for container_name, container_config in vyos_containers.items() %}
+{{ container(container_name, container_config) }}
 
-[Install]
-WantedBy=multi-user.target default.target
-EOT
-
-systemctl daemon-reload
-systemctl start coredns
-{% endif -%}
+{% endfor -%}

--- a/templates/macros/container.j2
+++ b/templates/macros/container.j2
@@ -1,0 +1,47 @@
+{# Template that generates container systemd units #}
+{%- macro container(name, config) -%}
+  {%- set run_args = [] -%}
+
+  {%- for volume in (config['volumes'] | default([])) -%}
+    {%- set _ = run_args.append('-v') -%}
+    {%- set _ = run_args.append(volume) -%}
+  {%- endfor -%}
+
+  {%- for cap in (config['cap_add'] | default([])) -%}
+    {%- set _ = run_args.append('--cap-add') -%}
+    {%- set _ = run_args.append(cap) -%}
+  {%- endfor -%}
+
+  {%- if config['env'] is defined -%}
+    {%- for key, value in config['env'].items() -%}
+      {%- set _ = run_args.append('--env') -%}
+      {%- set _ = run_args.append(key + '=' + value) -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {%- if (config['host-networking'] | default(false)) %}
+    {%- set _ = run_args.append('--net') -%}
+    {%- set _ = run_args.append('host') -%}
+  {%- endif -%}
+cat <<EOT > /etc/systemd/system/{{ name }}.service
+[Unit]
+Description={{ name }} container
+Wants=network.target
+After=network-online.target
+
+[Service]
+Restart=on-failure
+TimeoutStopSec=60
+ExecStartPre=/usr/bin/podman rm --force --volumes --ignore {{ name }}
+ExecStart=/usr/bin/podman run -d --rm --name {{ name }} {{ run_args | join(' ') }} {{ config['image']['repository'] }}:{{ config['image']['tag'] }}
+ExecStop=/usr/bin/podman stop -t 10 {{ name }}
+ExecStopPost=/usr/bin/podman stop -t 10 {{ name }}
+Type=forking
+
+[Install]
+WantedBy=multi-user.target default.target
+EOT
+
+systemctl daemon-reload
+systemctl start {{ name }}
+{%- endmacro %}


### PR DESCRIPTION
The VyOS built in `set container` has some limitations, in that not everything can be configured (such as `cap-add`).
Using the Ansible `podman` module could be an option, but the containers that it creates do not always properly survive a system restart because they are spun up before the system is actually ready.

This feature creates systemd unit files for the specified containers, so that they are started once the system has booted.

It also introduces a `vyos_run_post_config_script` (defaults to `true`) variable to control if the post-config script should be run on the router at the end of the Ansible run.