### PR TITLE
feat: bgp setting no-ipv4-unicast has been removed

### DIFF
--- a/templates/config/routing/bgp.j2
+++ b/templates/config/routing/bgp.j2
@@ -10,10 +10,7 @@
   {%- set _ = bgp_config.update({
     'local-as': vyos_bgp['local_as'],
     'parameters': {
-      'router-id': vyos_bgp['router_id'],
-      'default': {
-        'no-ipv4-unicast': {}
-      }
+      'router-id': vyos_bgp['router_id']
     }
   }) -%}
 


### PR DESCRIPTION
https://phabricator.vyos.net/T3741

This setting is now obsolete

Signed-off-by: Bᴇʀɴᴅ Sᴄʜᴏʀɢᴇʀs <me@bjw-s.dev>